### PR TITLE
Ensure DOM input field gets updated whenever the `selectedDate` changes.

### DIFF
--- a/bootstrap-datepicker.js
+++ b/bootstrap-datepicker.js
@@ -7,8 +7,6 @@
  * Contributed by Scott Torborg - github.com/storborg
  * Loosely based on jquery.date_input.js by Jon Leighton, heavily updated and
  * rewritten to match bootstrap javascript approach and add UI features.
- * 
- * Bug fixes and improvements by Ramesh Nair (github.com/hiddentao)
  * =========================================================== */
 
 


### PR DESCRIPTION
At the moment, when you navigate through the months the `selectedDate` gets updated but the DOM input field to which the datepicker is attached doesn't. This pull request fixes that.
